### PR TITLE
delete image on entity removal.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Give permissions for var
         run: sudo chmod -R 777 var/
 
-      - name: Give permissions for assets/uploads
-        run: chmod -R 777 assets/uploads
+      - name: Create assets/uploads directory and give permissions
+        run: mkdir -p assets/uploads && chmod -R 777 assets/uploads
 
       - name: Create the phpunit.xml
         run: docker compose exec --user root php cp phpunit.xml.dist phpunit.xml
@@ -71,6 +71,9 @@ jobs:
 
       - name: Run fixtures
         run: docker compose exec --user root php bin/console d:f:l -n --purge-exclusions=city --purge-exclusions=state
+
+      - name: Give permissions for assets/uploads
+        run: docker compose exec --user root php chmod -R 777 assets/uploads
 
       - name: Install frontend dependencies
         run: docker compose exec --user root php bin/console importmap:install

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ coverage.xml
 
 ###> symfony/asset-mapper ###
 /public/assets/
+/assets/uploads/
 /assets/vendor/
 ###< symfony/asset-mapper ###
 

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ reset:
 # Limpa a cache e o banco
 reset-deep:
 	rm -rf var/storage
+	rm -rf assets/uploads
 	rm -rf assets/vendor
 	rm -rf public/assets
 	rm -rf var/cache

--- a/assets/uploads/.gitignore
+++ b/assets/uploads/.gitignore
@@ -1,2 +1,0 @@
-/*
-!.gitignore

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -33,7 +33,7 @@ RUN groupadd -g 1000 developer && useradd -u 1000 -ms /bin/bash -g developer use
 
 COPY --chown=user:developer . /var/www
 
-RUN chown -R www-data /var/www/assets/uploads
+RUN mkdir -p /var/www/assets/uploads && chown -R www-data /var/www/assets/uploads
 
 RUN pecl install xdebug \
     && docker-php-ext-enable xdebug \

--- a/src/Service/AgentService.php
+++ b/src/Service/AgentService.php
@@ -166,6 +166,11 @@ readonly class AgentService extends AbstractEntityService implements AgentServic
         }
 
         $agent->setDeletedAt(new DateTime());
+
+        if ($agent->getImage()) {
+            $this->fileService->deleteFileByUrl($agent->getImage());
+        }
+
         $this->repository->save($agent);
     }
 

--- a/src/Service/EventService.php
+++ b/src/Service/EventService.php
@@ -127,6 +127,10 @@ readonly class EventService extends AbstractEntityService implements EventServic
 
         $event->setDeletedAt(new DateTime());
 
+        if ($event->getImage()) {
+            $this->fileService->deleteFileByUrl($event->getImage());
+        }
+
         $this->repository->save($event);
     }
 

--- a/src/Service/FileService.php
+++ b/src/Service/FileService.php
@@ -53,7 +53,9 @@ readonly class FileService implements FileServiceInterface
     {
         $filename = str_replace($this->storageUrl, '', $url);
 
-        $this->filesystem->delete($filename);
+        $path = dirname(__DIR__, 2)."/assets{$filename}";
+
+        unlink($path);
     }
 
     public function getFileUrl(string $path): string

--- a/src/Service/InitiativeService.php
+++ b/src/Service/InitiativeService.php
@@ -116,6 +116,10 @@ readonly class InitiativeService extends AbstractEntityService implements Initia
         $initiative = $this->get($id);
         $initiative->setDeletedAt(new DateTime());
 
+        if ($initiative->getImage()) {
+            $this->fileService->deleteFileByUrl($initiative->getImage());
+        }
+
         $this->repository->save($initiative);
     }
 

--- a/src/Service/OpportunityService.php
+++ b/src/Service/OpportunityService.php
@@ -123,6 +123,10 @@ readonly class OpportunityService extends AbstractEntityService implements Oppor
 
         $opportunity->setDeletedAt(new DateTime());
 
+        if ($opportunity->getImage()) {
+            $this->fileService->deleteFileByUrl($opportunity->getImage());
+        }
+
         $this->repository->save($opportunity);
     }
 

--- a/src/Service/OrganizationService.php
+++ b/src/Service/OrganizationService.php
@@ -118,6 +118,10 @@ readonly class OrganizationService extends AbstractEntityService implements Orga
 
         $organization->setDeletedAt(new DateTime());
 
+        if ($organization->getImage()) {
+            $this->fileService->deleteFileByUrl($organization->getImage());
+        }
+
         $this->repository->save($organization);
     }
 

--- a/src/Service/SpaceService.php
+++ b/src/Service/SpaceService.php
@@ -123,6 +123,10 @@ readonly class SpaceService extends AbstractEntityService implements SpaceServic
 
         $space->setDeletedAt(new DateTime());
 
+        if ($space->getImage()) {
+            $this->fileService->deleteFileByUrl($space->getImage());
+        }
+
         $this->repository->save($space);
     }
 

--- a/tests/Functional/Services/FileServiceTest.php
+++ b/tests/Functional/Services/FileServiceTest.php
@@ -46,6 +46,19 @@ class FileServiceTest extends KernelTestCase
         $this->fileService->readFile(self::FILE);
     }
 
+    public function testDeleteFileByUrl(): void
+    {
+        $this->fileService->uploadFile(self::FILE, self::CONTENT);
+
+        $storageUrl = $this->fileService->getFileUrl('');
+        $fileUrl = $storageUrl.'/'.self::FILE;
+        $filePath = dirname(__DIR__, 2).'/assets/'.self::FILE;
+
+        $this->fileService->deleteFileByUrl($fileUrl);
+
+        $this->assertFalse(file_exists($filePath));
+    }
+
     public function testUploadImage(): void
     {
         $uploadedFile = ImageTestFixtures::getImageValid();


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Branch?       | feat/delete-image-on-entity-removal                                               |
| Bug fix?      | no                                                                                                                    |
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->                                                                   |
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->                                                  |
| Issues        | Fix #107  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |

### Descrição da Mudança

1. Nesta atualização, substituí a chamada `filesystem->delete($filename)` por `unlink($path)` porque o método anterior não estava conseguindo excluir a imagem. A mudança visa garantir que as imagens sejam removidas corretamente.

2. Ajuste no Makefile: Modifiquei o comando `reset-deep` para garantir a remoção da pasta `assets/uploads`, permitindo uma limpeza adequada do ambiente de desenvolvimento.

2. Adição ao .gitignore: Fiz algumas mudanças para resolver um problema que acontecia ao rodar o comando `reset deep`. Sempre que esse comando era executado, a pasta `.gitignore` dentro de `assets/uploads` era excluída. Para evitar essa situação, adicionei a pasta `assets/uploads` ao `.gitignore` geral do projeto. Assim, os arquivos gerados nessa pasta durante o desenvolvimento não serão adicionados ao repositório.

4. Atualização no Dockerfile: Adicionei um comando para criar a pasta `assets/uploads` antes de iniciar o container e ajustar suas permissões. Isso evita erros relacionados à ausência da pasta, garantindo que tudo funcione corretamente.

