### PR TITLE
Adds test for UserAdminController.

### DIFF
--- a/tests/Functional/Controller/Web/Admin/UserAdminWebControllerTest.php
+++ b/tests/Functional/Controller/Web/Admin/UserAdminWebControllerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller\Web\Admin;
+
+use App\Controller\Web\Admin\UserAdminController;
+use App\DataFixtures\Entity\UserFixtures;
+use App\Tests\AbstractAdminWebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Uid\Uuid;
+
+class UserAdminWebControllerTest extends AbstractAdminWebTestCase
+{
+    private UserAdminController $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->controller = static::getContainer()->get(UserAdminController::class);
+    }
+
+    public function testListPageRenderHTMLWithSuccess(): void
+    {
+        $listUrl = $this->router->generate('admin_user_list');
+
+        $this->client->request(Request::METHOD_GET, $listUrl);
+
+        $response = $this->client->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h2', $this->translator->trans('Usuários'));
+        $this->assertSelectorTextContains('tr  th:nth-of-type(1)', $this->translator->trans('name'));
+        $this->assertSelectorTextContains('tr  th:nth-of-type(2)', $this->translator->trans('email'));
+        $this->assertSelectorTextContains('tr  th:nth-of-type(3)', $this->translator->trans('image'));
+        $this->assertSelectorTextContains('tr  th:nth-of-type(4)', $this->translator->trans('created_at'));
+        $this->assertSelectorTextContains('tr  th:nth-of-type(5)', $this->translator->trans('actions'));
+    }
+
+    public function testControllerListMethodDirectly(): void
+    {
+        $this->assertInstanceOf(Response::class, $this->controller->list());
+    }
+
+    public function testTimelinePageRenderHTMLWithSuccess(): void
+    {
+        $timelineUrl = $this->router->generate('admin_user_timeline', [
+            'id' => Uuid::fromString(UserFixtures::USER_ID_3),
+        ]);
+
+        $this->client->request(Request::METHOD_GET, $timelineUrl);
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testTimelineNotFound(): void
+    {
+        $timelineUrl = $this->router->generate('admin_user_timeline', [
+            'id' => Uuid::v4()->toRfc4122(),
+        ]);
+
+        $this->client->request(Request::METHOD_GET, $timelineUrl);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testAccountPrivacyPageRenderHTMLWithSuccess(): void
+    {
+        $accountPrivacyUrl = $this->router->generate('admin_user_account_privacy', [
+            'id' => Uuid::fromString(UserFixtures::USER_ID_3),
+        ]);
+
+        $this->client->request(Request::METHOD_GET, $accountPrivacyUrl);
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testAccountPrivacyRedirectsToLoginWhenUserNotFound(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/logout');
+
+        $accountPrivacyUrl = $this->router->generate('admin_user_account_privacy', [
+            'id' => Uuid::v4()->toRfc4122(),
+        ]);
+
+        $this->client->request(Request::METHOD_GET, $accountPrivacyUrl);
+
+        $this->assertResponseRedirects('/login', Response::HTTP_FOUND);
+    }
+}


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Branch?       |feat/user-admin-controller-test                                           |
| Bug fix?      | no                                                                                                                    |
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->                                                                   |
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->                                                  |
| Issues        | Fix #200  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |

![image](https://github.com/user-attachments/assets/9fa87ec3-f187-48f4-8769-34b16c65b70d)


##### Por algum motivo o método `testAccountPrivacyRedirectsToLoginWhenUserNotFound() ` não teve a cobertura esperada na linha `return $this->redirectToRoute('login');` : 

![image](https://github.com/user-attachments/assets/eed86546-554a-4adb-8f96-7d673be0b4bf)
