### PR TITLE
Remove cypress and node_modules from php cs fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -8,7 +8,7 @@ use PhpCsFixer\Finder;
 $finder = (new Finder())
     ->ignoreDotFiles(false)
     ->ignoreVCSIgnored(true)
-    ->exclude(['logs', 'var', 'vendor'])
+    ->exclude(['logs', 'var', 'vendor', 'cypress', 'node_modules'])
     ->in(__DIR__);
 
 return (new Config())


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Branch?       | improv/php-cs-fixer-exclude |
| Bug fix?      | no |
| New feature?  | yes |
| Deprecations? | no |
| Issues        | Fix #423|

<img width="1337" height="755" alt="image" src="https://github.com/user-attachments/assets/d009eb19-1bc6-40eb-8620-2ecd1932b7d6" />
