### PR TITLE
Prevent user enumeration on password reset

### DIFF
--- a/src/Controller/Web/AccountEventWebController.php
+++ b/src/Controller/Web/AccountEventWebController.php
@@ -73,7 +73,6 @@ class AccountEventWebController extends AbstractWebController
         try {
             $this->accountEventService->sendResetPasswordEmail($email);
         } catch (UserResourceNotFoundException) {
-            return $this->redirectToRoute('web_home_homepage');
         }
 
         $this->addFlash('success', $this->translator->trans('view.authentication.forgot.link_sent_to_email'));


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Branch?       | fix/security-password-reset                 |
| Bug fix?      | yes                                                                                                               |
| New feature?  |no                                                            |
| Deprecations? | no                                   |
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |

Este PR corrige uma falha de segurança que permitia a enumeração de usuários.

Anteriormente, o sistema retornava respostas diferentes para e-mails existentes e não existentes, permitindo que um atacante descobrisse quais usuários estão registrados.

Se o e-mail não estivesse cadastrado, o usuário era redirecionado para a home sem mostrar a mensagem.

A correção garante que a resposta seja sempre a mesma, exibindo a mensagem "Link de recuperação enviado ao e-mail!" e redirecionando o usuário, independentemente de o e-mail ter sido encontrado ou não.