### PR TITLE
improv opportunity detail responsive page

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -313,6 +313,10 @@ body {
     margin-top: 3rem;
 }
 
+.profile-entity-wrapper {
+    margin: 1.563rem 8.2rem;
+}
+
 .entry-fee, .participants {
     margin-right: 30px;
     display: flex;
@@ -1146,6 +1150,10 @@ img.card-images__entity-details {
 
     .entity-page-tabs p {
         padding-top: 0.8rem;
+    }
+
+    .profile-entity-wrapper {
+        margin: 1.5rem 1rem !important;
     }
 
     .pill-tabs {

--- a/assets/styles/components/entity-header.css
+++ b/assets/styles/components/entity-header.css
@@ -1,0 +1,161 @@
+.entity-banner {
+    position: relative;
+}
+
+.entity-banner img {
+    height: 256px;
+    width: 100%;
+    object-fit: cover;
+}
+
+.entity-profile-bio {
+    padding-left: 8.5rem;
+    padding-right: 8.625rem;
+    margin-top: -3.75rem;
+    background: linear-gradient(to bottom, transparent 20%, white 80%);
+    box-shadow: 0 4px 8px 0 var(--box-shadow-color);
+}
+
+.entity-profile-bio .entity-profile-label {
+    height: 2rem;
+    border-radius: 45px;
+    background-color: var(--color-highlight);
+    font-size: 14px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 0.406rem 1rem;
+    line-height: 0;
+}
+
+.entity-profile-bio .entity-profile-label i {
+    font-size: 1.5rem;
+}
+
+.entity-profile-bio .entity-description {
+    margin-top: 12px;
+    max-width: 93.75rem;
+    max-height: 3.125rem;
+}
+
+.entity-photo img {
+    width: 7.5rem;
+    height: 7.5rem;
+    border-radius: 50%;
+    border: 0.0625rem solid var(--dark-gray);
+    z-index: 1;
+}
+
+.entity-profile-actions button {
+    width: auto;
+    min-width: 12.5rem;
+    height: 3rem;
+    border: none;
+    background-color: var(--deep-teal);
+    color: var(--white-color);
+    font-weight: 700;
+    border-radius: 0.5rem;
+    padding: 0.75rem 1.5rem;
+}
+
+.entity-profile-actions button i {
+    font-size: 1.4rem;
+}
+
+.entity-profile-actions button:first-child {
+    background-color: var(--white-color);
+    color: var(--deep-teal);
+    border: 2px solid var(--deep-teal);
+    padding: 1rem 1rem;
+}
+
+.entity-profile-actions button:nth-child(2) i {
+    height: 1.0625rem;
+}
+
+.profile-tabs, .perfil-tabs {
+    margin-left: -15px;
+}
+
+.profile-tabs .entity-page-tabs, .perfil-tabs .entity-page-tabs{
+    margin: 0;
+    padding: 0;
+}
+
+.profile-tabs span {
+    color: var(--paleGray);
+}
+
+@media (max-width: 48rem) {
+    .entity-profile-bio {
+        padding-left: 1.5rem;
+        padding-right: 1.5rem;
+        padding-bottom: 1.5rem;
+    }
+
+    .entity-banner .breadcrumb {
+        margin-left: 1.5rem;
+    }
+
+    .entity-photo {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: 1rem;
+    }
+
+    .entity-profile-bio > .d-flex.justify-content-between {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .entity-profile-bio .entity-profile-label {
+        height: auto;
+        min-height: 2rem;
+        line-height: 1.2;
+        text-align: center;
+        justify-content: center;
+        white-space: normal;
+    }
+
+    .entity-profile-bio .entity-description {
+        max-height: none;
+        margin-bottom: 1.5rem;
+        text-align: center;
+    }
+
+    .profile-tabs {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
+    }
+
+    .entity-profile-actions {
+        position: absolute;
+        top: 3.75rem;
+        right: 1.5rem;
+        transform: translateY(-50%);
+        margin-top: 0 !important;
+        z-index: 10;
+    }
+
+    .entity-profile-actions button,
+    .entity-profile-actions button:first-child {
+        width: 2.5rem;
+        height: 2.5rem;
+        min-width: 0;
+        padding: 0;
+        border-radius: 50%;
+    }
+
+    .entity-profile-actions button i {
+        font-size: 1.2rem;
+        margin: 0;
+        height: auto;
+    }
+
+    .entity-page-tabs {
+        width: 100%;
+    }
+}

--- a/assets/styles/pages/agents.css
+++ b/assets/styles/pages/agents.css
@@ -25,98 +25,6 @@
     min-height: 100vh;
 }
 
-.entity-banner {
-    position: relative;
-}
-
-.entity-banner img {
-    height: 256px;
-    width: 100%;
-    object-fit: cover;
-}
-
-.entity-profile-bio {
-    padding-left: 8.5rem;
-    padding-right: 8.625rem;
-    margin-top: -3.75rem;
-    background: linear-gradient(to bottom, transparent 20%, white 80%);
-    box-shadow: 0 4px 8px 0 var(--box-shadow-color);
-}
-
-.entity-photo img {
-    width: 7.5rem;
-    height: 7.5rem;
-    border-radius: 50%;
-    border: 0.0625rem solid var(--dark-gray);
-    z-index: 1;
-}
-
-.entity-profile-bio .entity-profile-label {
-    height: 2rem;
-    border-radius: 45px;
-    background-color: var(--color-highlight);
-    font-size: 14px;
-    font-weight: 700;
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    padding: 0.406rem 1rem;
-    line-height: 0;
-}
-
-.entity-profile-bio .entity-profile-label i {
-    font-size: 1.5rem;
-}
-
-.entity-profile-actions button {
-    width: 12.5rem;
-    height: 3rem;
-    border: none;
-    background-color: var(--deep-teal);
-    color: var(--white-color);
-    font-weight: 700;
-    border-radius: 8px;
-    padding: 0.75rem 0.656rem;
-}
-
-.entity-profile-actions button i {
-    font-size: 1.4rem;
-}
-
-.entity-profile-actions button:nth-child(2) i {
-    height: 17px;
-}
-
-.entity-profile-actions button:first-child {
-    background-color: var(--white-color);
-    color: var(--deep-teal);
-    border: 2px solid var(--deep-teal);
-    padding: 1rem 1rem;
-}
-
-.entity-profile-bio .entity-description {
-    margin-top: 12px;
-    max-width: 93.75rem;
-    max-height: 3.125rem;
-}
-
-.profile-tabs, .perfil-tabs {
-    margin-left: -15px;
-}
-
-.profile-tabs .entity-page-tabs, .perfil-tabs .entity-page-tabs{
-    margin: 0;
-    padding: 0;
-}
-
-.profile-tabs span {
-    color: var(--paleGray);
-}
-
-.profile-entity-wrapper {
-    margin: 1.563rem 8.2rem;
-}
-
 .profile-entity-wrapper .agent-organizations {
     background-color: var(--white-color);
     height: auto;
@@ -280,18 +188,6 @@
     margin-left: 0.625rem;
 }
 
-.entity-profile-actions button {
-    width: auto;
-    min-width: 12.5rem;
-    height: 3rem;
-    border: none;
-    background-color: var(--deep-teal);
-    color: var(--white-color);
-    font-weight: 700;
-    border-radius: 0.5rem;
-    padding: 0.75rem 1.5rem;
-}
-
 @media (max-width: 768px) {
     .agent-card-header {
         flex-direction: column;
@@ -322,76 +218,6 @@
         text-align: center;
         padding-right: 0;
         margin-right: 0;
-    }
-
-    .entity-profile-bio {
-        padding-left: 1.5rem;
-        padding-right: 1.5rem;
-        padding-bottom: 1.5rem;
-    }
-
-    .entity-banner .breadcrumb {
-        margin-left: 1.5rem;
-    }
-
-    .entity-profile-bio > .d-flex.justify-content-between {
-        flex-direction: column;
-        align-items: center;
-    }
-
-    .entity-photo {
-        flex-direction: column;
-        align-items: center;
-        text-align: center;
-        gap: 1rem;
-    }
-
-    .entity-profile-bio .entity-profile-label {
-        height: auto;
-        min-height: 2rem;
-        line-height: 1.2;
-        text-align: center;
-        justify-content: center;
-        white-space: normal;
-    }
-
-    .entity-profile-bio .entity-description {
-        max-height: none;
-        margin-bottom: 1.5rem;
-    }
-
-    .profile-tabs {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 1rem;
-    }
-
-    .profile-entity-wrapper {
-        margin: 1.5rem 1rem !important;
-    }
-
-    .entity-profile-actions {
-        position: absolute;
-        top: 3.75rem;
-        right: 1.5rem;
-        transform: translateY(-50%);
-        margin-top: 0 !important;
-        z-index: 10;
-    }
-
-    .entity-profile-actions button,
-    .entity-profile-actions button:first-child {
-        width: 2.5rem;
-        height: 2.5rem;
-        min-width: 0;
-        padding: 0;
-        border-radius: 50%;
-    }
-
-    .entity-profile-actions button i {
-        font-size: 1.2rem;
-        margin: 0;
-        height: auto;
     }
 
     .agent-profile-actions button,

--- a/src/Controller/Web/AgentWebController.php
+++ b/src/Controller/Web/AgentWebController.php
@@ -56,7 +56,7 @@ class AgentWebController extends AbstractWebController
         $events = $this->eventService->findByAgent($agent->getId()->toRfc4122());
         $spaces = $this->spaceService->findBy(['createdBy' => $agent]);
 
-        return $this->render('agent/one.html.twig', [
+        return $this->render('agent/details.html.twig', [
             'agent' => $agent,
             'events' => $events,
             'spaces' => $spaces,

--- a/templates/_components/entity-header.html.twig
+++ b/templates/_components/entity-header.html.twig
@@ -1,46 +1,53 @@
 <div class="entity-banner">
-    <img src="{{ asset(coverImage ?? 'img/banner.jpeg') }}" alt="{{ 'entity_banner' | trans }}">
-    {% include '_components/breadcrumb.html.twig' with {
-        items: [
-            {text: 'home'|trans, path: path('web_home_homepage')},
-            {text: 'agents'|trans, path: path('web_agent_list')},
-            {text: name, path: path('web_agent_getOne', {'id': agent.id})}
-        ]
-    } %}
+    <img src="{{ asset(coverImage|default('img/banner.jpeg')) }}" alt="{{ 'entity_banner' | trans }}">
+    {% if breadcrumbs|default %}
+        {% include '_components/breadcrumb.html.twig' with {
+            items: breadcrumbs
+        } only %}
+    {% endif %}
 </div>
 
 <div class="entity-profile-bio position-relative">
-    <div class="d-flex justify-content-between align-items-center align-items-lg-end">
+    <div class="d-flex justify-content-between align-items-center align-items-lg-start">
+        <div class="entity-photo d-flex align-items-center align-items-lg-start gap-3 gap-lg-4 text-center text-lg-start">
+            <img src="{{ asset(image|default('img/user.png')) }}" alt="{{ 'photo' | trans }}">
+            <div class="d-flex flex-column d-lg-block align-items-center text-center text-lg-start mt-2 mt-lg-5 pt-lg-4 gap-2">
+                <h1 class="fs-2 mb-0 fw-bold d-lg-inline align-middle">{{ name }}</h1>
+                {% if label|default %}
+                    <span class="entity-profile-label d-lg-inline-flex align-middle ms-lg-3 mt-2 mt-lg-0 text-wrap">
+                        <i class="material-icons">{{ icon|default('person') }}</i>
+                        {{ label }}
+                    </span>
+                {% endif %}
 
-        <div class="entity-photo d-flex align-items-center align-items-lg-end gap-3 gap-lg-4 text-center text-lg-start">
-            <img src="{{ asset(image ?? 'img/user.png') }}" alt="{{ 'photo' | trans }}">
-            <div class="d-flex flex-column flex-lg-row align-items-center align-items-lg-end gap-2 gap-lg-3 mt-2 mt-lg-0">
-                <h1 class="fs-2 mb-0 fw-bold">{{ name }}</h1>
-                <span class="entity-profile-label text-wrap">
-                    <i class="material-icons">person</i>
-                    {{ agent.shortBio }}
-                </span>
+                {% if id|default %}
+                    <button
+                        class="btn btn-link btn-sm text-muted text-decoration-none copy-id
+                        d-lg-inline-flex align-items-center ms-lg-2 " data-id="{{ id }}"
+                        title="{{ 'copy_id' | trans }}"
+                    >
+                        <i class="material-icons fs-6 me-1">content_copy</i> Copiar ID
+                    </button>
+                {% endif %}
             </div>
         </div>
 
-        <div class="entity-profile-actions d-flex flex-row gap-2 gap-lg-4 mt-4 mt-lg-0">
-            <button class="d-flex align-items-center justify-content-center">
-                <i class="material-icons">share</i>
-                <span class="d-none d-lg-block ms-2 text-nowrap">{{ 'share' | trans }}</span>
-            </button>
-            <button class="d-flex align-items-center justify-content-center">
-                <i class="material-icons">chat_bubble</i>
-                <span class="d-none d-lg-block ms-2 text-nowrap">{{ 'send_message' | trans }}</span>
-            </button>
-        </div>
+        {% if actions|default %}
+            <div class="entity-profile-actions d-flex flex-row gap-2 gap-lg-4 mt-4 mt-lg-5 pt-lg-4">
+                {% include actions with actionData|default({}) %}
+            </div>
+        {% endif %}
     </div>
 
-    <div class="entity-description mt-3 mt-lg-2">
-        <p>{{ longBio }}</p>
-    </div>
+    {% if longBio|default %}
+        <div class="entity-description mt-3 mt-lg-2">
+            <p>{{ longBio }}</p>
+        </div>
+    {% endif %}
 
     <div class="profile-tabs d-flex align-items-start align-items-lg-center gap-3 mt-4 mt-lg-2">
-        {% include tabs %}
-        <span class="text-break">{{ 'identification_number' | trans }}: {{ id }}</span>
+        {% if tabs|default %}
+            {% include tabs %}
+        {% endif %}
     </div>
 </div>

--- a/templates/agent/_partials/actions.html.twig
+++ b/templates/agent/_partials/actions.html.twig
@@ -1,0 +1,8 @@
+<button class="d-flex align-items-center justify-content-center">
+    <i class="material-icons">share</i>
+    <span class="d-none d-lg-block ms-2 text-nowrap">{{ 'share' | trans }}</span>
+</button>
+<button class="d-flex align-items-center justify-content-center">
+    <i class="material-icons">chat_bubble</i>
+    <span class="d-none d-lg-block ms-2 text-nowrap">{{ 'send_message' | trans }}</span>
+</button>

--- a/templates/agent/details.html.twig
+++ b/templates/agent/details.html.twig
@@ -5,6 +5,7 @@
 {% block stylesheets %}
     {{ parent() }}
     <link rel="stylesheet" href="{{ asset('styles/pages/agents.css') }}">
+    <link rel="stylesheet" href="{{ asset('styles/components/entity-header.css') }}">
 {% endblock %}
 
 {% block content %}
@@ -12,11 +13,19 @@
         {% include "_components/entity-header.html.twig" with {
             name: agent.name,
             id: agent.id,
-            tabs: 'agent/_partials/profile-tabs/profile-tabs.html.twig',
+            icon: 'person',
+            label: agent.shortBio,
             longBio: agent.longBio,
             image: agent.image,
-            coverImage: agent.user.coverImage
-        } %}
+            coverImage: agent.user.coverImage,
+            actions: 'agent/_partials/actions.html.twig',
+            tabs: 'agent/_partials/profile-tabs/profile-tabs.html.twig',
+            breadcrumbs: [
+                {text: 'home'|trans, path: path('web_home_homepage')},
+                {text: 'agents'|trans, path: path('web_agent_list')},
+                {text: agent.name, path: path('web_agent_getOne', {'id': agent.id})}
+            ]
+        } only %}
     </section>
 
     <section class="profile-entity-wrapper">

--- a/templates/opportunity/_partials/details/_info-btns.html.twig
+++ b/templates/opportunity/_partials/details/_info-btns.html.twig
@@ -1,6 +1,0 @@
-<button type="button" class="btn btn-outline-success btn-outline__entity-details fw-bold py-2 px-4">
-    <i class="material-icons fs-4 me-2">share</i> {{ 'share'|trans }}
-</button>
-<button type="button" class="btn btn-primary fw-bold p-2 ms-3">
-    <i class="material-icons fs-4 me-2">messenger</i> {{ 'send_message'|trans }}
-</button>

--- a/templates/opportunity/_partials/details/actions.html.twig
+++ b/templates/opportunity/_partials/details/actions.html.twig
@@ -1,0 +1,8 @@
+<button class="d-flex align-items-center justify-content-center">
+    <i class="material-icons">share</i>
+    <span class="d-none d-lg-block ms-2 text-nowrap">{{ 'share' | trans }}</span>
+</button>
+<button class="d-flex align-items-center justify-content-center">
+    <i class="material-icons">chat_bubble</i>
+    <span class="d-none d-lg-block ms-2 text-nowrap">{{ 'send_message' | trans }}</span>
+</button>

--- a/templates/opportunity/_partials/details/content-tabs.html.twig
+++ b/templates/opportunity/_partials/details/content-tabs.html.twig
@@ -1,0 +1,23 @@
+{% set tabs = [
+    {
+        'id': 'generalData',
+        'content': include('opportunity/_partials/details/general-data.html.twig')
+    },
+    {
+        'id': 'workPlan',
+        'content': include('opportunity/_partials/details/work-plan.html.twig')
+    },
+    {
+        'id': 'events',
+        'content': include('opportunity/_partials/details/events.html.twig')
+    },
+    {
+        'id': 'people',
+        'content': include('opportunity/_partials/details/peoples.html.twig')
+    },
+    {
+        'id': 'connections',
+        'content': include('opportunity/_partials/details/connections.html.twig')
+    }
+] %}
+{% include '_components/tabs/content-tabs.html.twig' with { 'tabs': tabs } %}

--- a/templates/opportunity/_partials/details/general-data.html.twig
+++ b/templates/opportunity/_partials/details/general-data.html.twig
@@ -1,4 +1,4 @@
-<div class="tab-pane container active" id="generalData">
+<div class="tab-pane container-fluid px-0 px-md-1 active" id="generalData">
     {% if opportunity.parent %}
         <div class="card shadow-sm mb-3 card__entity-details">
             <div class="card-body py-4">

--- a/templates/opportunity/_partials/details/tabs.html.twig
+++ b/templates/opportunity/_partials/details/tabs.html.twig
@@ -1,0 +1,26 @@
+<div class="entity-page-tabs">
+    {% set tabs = [
+        {
+            'id': 'generalData',
+            'title': 'general_data' | trans,
+        },
+        {
+            'id': 'workPlan',
+            'title': 'work_plan' | trans,
+        },
+        {
+            'id': 'events',
+            'title': 'events' | trans,
+        },
+        {
+            'id': 'people',
+            'title': 'people' | trans
+        },
+        {
+            'id': 'connections',
+            'title': 'connections' | trans
+        }
+    ] %}
+
+    {% include '_components/tabs/tab.html.twig' with { 'tabs': tabs } %}
+</div>

--- a/templates/opportunity/details.html.twig
+++ b/templates/opportunity/details.html.twig
@@ -6,75 +6,74 @@
 
 {% block stylesheets %}
     {{ parent() }}
-    <link rel="stylesheet" href="{{ asset('styles/pages/initiatives.css') }}">
+    <link rel="stylesheet" href="{{ asset('styles/pages/agents.css') }}">
 {% endblock %}
 
 {% block content %}
-    <div class="container-fluid px-0 bg-white shadow position-relative">
+    <div class="entity-banner">
         <img
-            class="w-100 object-fit-cover bg-white"
-            style="aspect-ratio: 5.65"
-            src="{{ opportunity.coverImage ?? asset('img/entity-cover-image.png') }}"
-            alt="{{ 'opportunity'|trans }} | {{ 'cover_image'|trans }}"
+                class="w-100 object-fit-cover bg-white"
+                style="aspect-ratio: 5.65"
+                src="{{ opportunity.coverImage ?? asset('img/entity-cover-image.png') }}"
+                alt="{{ 'opportunity'|trans }} | {{ 'cover_image'|trans }}"
         >
 
-        <div class="container">
+        <div class="container mt-2">
             <div class="breadcrumb pt-sm-4 breadcrumb__entity-details">
                 <a href="{{ path('web_home_homepage') }}">{{ 'home'|trans }}</a>
                 <a href="{{ path('web_opportunity_list') }}">{{ 'opportunities'|trans }}</a>
                 <a href="{{ path('web_opportunity_details', {id: opportunity.id}) }}">{{ opportunity.name }}</a>
             </div>
         </div>
+    </div>
 
-        <div class="container position-relative">
-            <div class="d-flex mb-3 entity-info-wrapper">
-                <img class="entity-image rounded-circle bg-white" src="{{ opportunity.image ?? asset('img/entity-image.png') }}" alt="{{ 'opportunity'|trans }} | {{ 'image'|trans }}">
+    <div class="container py-4">
+        <div class="entity-profile-bio position-relative">
+            <div class="d-flex justify-content-between align-items-center align-items-lg-end">
+                <div class="entity-photo d-flex align-items-center align-items-lg-end gap-3 gap-lg-4 text-center text-lg-start">
+                    <img class="rounded-circle bg-white shadow-sm" style="width: 120px; height: 120px; object-fit: cover;" src="{{ opportunity.image ?? asset('img/entity-image.png') }}" alt="{{ 'opportunity'|trans }} | {{ 'image'|trans }}">
 
-                <h2 class="name__entity-details fw-bold ms-2 mt-2 ms-sm-4 mt-sm-3">{{ opportunity.name }}</h2>
+                    <div class="d-flex flex-column flex-lg-row align-items-center align-items-lg-end gap-2 gap-lg-3 mt-2 mt-lg-0">
+                        <h1 class="fs-2 mb-0 fw-bold name__entity-details">{{ opportunity.name }}</h1>
+                    </div>
+                </div>
 
-                <div class="ms-auto mt-3 d-none d-xxl-inline">
+                <div class="entity-profile-actions d-flex flex-row gap-2 gap-lg-4 mt-4 mt-lg-0">
                     {% include "opportunity/_partials/details/_info-btns.html.twig" %}
                 </div>
             </div>
 
-            <div class="mb-3 d-xxl-none">
-                {% include "opportunity/_partials/details/_info-btns.html.twig" %}
+            <div class="entity-description mt-3 mt-lg-4">
+                <p data-cy="short-description"></p>
+                <p class="text-secondary id__entity-details mb-xxl-0">{{ 'view.opportunity.id' | trans }}: {{ opportunity.id }}</p>
             </div>
 
-            <p data-cy="short-description"></p>
-
-            <p class="text-secondary id__entity-details mb-xxl-0">{{ 'view.opportunity.id' | trans }}: {{ opportunity.id }}</p>
-
-            <ul class="nav nav-pills">
-                <li class="nav-item">
-                    <a class="nav-link active" data-bs-toggle="pill" href="#generalData">{{ 'general_data'|trans }}</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" data-bs-toggle="pill" href="#workPlan">{{ 'work_plan'|trans }}</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" data-bs-toggle="pill" href="#events">{{ 'events'|trans }}</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" data-bs-toggle="pill" href="#people">{{ 'people'|trans }}</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" data-bs-toggle="pill" href="#connections">{{ 'connections'|trans }}</a>
-                </li>
-            </ul>
+            <div class="profile-tabs d-flex align-items-start align-items-lg-center gap-3 mt-4 mt-lg-2">
+                <ul class="nav nav-pills flex-wrap">
+                    <li class="nav-item">
+                        <a class="nav-link active" data-bs-toggle="pill" href="#generalData">{{ 'general_data'|trans }}</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" data-bs-toggle="pill" href="#workPlan">{{ 'work_plan'|trans }}</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" data-bs-toggle="pill" href="#events">{{ 'events'|trans }}</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" data-bs-toggle="pill" href="#people">{{ 'people'|trans }}</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" data-bs-toggle="pill" href="#connections">{{ 'connections'|trans }}</a>
+                    </li>
+                </ul>
+            </div>
         </div>
-    </div>
 
-    <div class="container py-4">
-        <div class="tab-content">
+        <div class="tab-content mt-4">
             {% include "opportunity/_partials/details/general-data.html.twig" %}
-
             {% include "opportunity/_partials/details/work-plan.html.twig" %}
-
             {% include "opportunity/_partials/details/events.html.twig" %}
-
             {% include "opportunity/_partials/details/peoples.html.twig" %}
-
             {% include "opportunity/_partials/details/connections.html.twig" %}
         </div>
     </div>

--- a/templates/opportunity/details.html.twig
+++ b/templates/opportunity/details.html.twig
@@ -6,76 +6,30 @@
 
 {% block stylesheets %}
     {{ parent() }}
-    <link rel="stylesheet" href="{{ asset('styles/pages/initiatives.css') }}">
+    <link rel="stylesheet" href="{{ asset('styles/components/entity-header.css') }}">
 {% endblock %}
 
 {% block content %}
-    <div class="container-fluid px-0 bg-white shadow position-relative">
-        <img
-            class="w-100 object-fit-cover bg-white"
-            style="aspect-ratio: 5.65"
-            src="{{ opportunity.coverImage ?? asset('img/entity-cover-image.png') }}"
-            alt="{{ 'opportunity'|trans }} | {{ 'cover_image'|trans }}"
-        >
+    <section class="entity-section">
+        {% include "_components/entity-header.html.twig" with {
+            name: opportunity.name,
+            id: opportunity.id,
+            image: opportunity.image ?? 'img/entity-image.png',
+            coverImage: opportunity.coverImage ?? 'img/entity-cover-image.png',
+            icon: 'lightbulb',
+            label: opportunity.extraFields.type,
+            longBio: opportunity.description,
+            actions: 'opportunity/_partials/details/actions.html.twig',
+            tabs: 'opportunity/_partials/details/tabs.html.twig',
+            breadcrumbs: [
+                {text: 'home'|trans, path: path('web_home_homepage')},
+                {text: 'opportunities'|trans, path: path('web_opportunity_list')},
+                {text: opportunity.name, path: path('web_opportunity_details', {id: opportunity.id})}
+            ]
+        } only %}
+    </section>
 
-        <div class="container">
-            <div class="breadcrumb pt-sm-4 breadcrumb__entity-details">
-                <a href="{{ path('web_home_homepage') }}">{{ 'home'|trans }}</a>
-                <a href="{{ path('web_opportunity_list') }}">{{ 'opportunities'|trans }}</a>
-                <a href="{{ path('web_opportunity_details', {id: opportunity.id}) }}">{{ opportunity.name }}</a>
-            </div>
-        </div>
-
-        <div class="container position-relative">
-            <div class="d-flex mb-3 entity-info-wrapper">
-                <img class="entity-image rounded-circle bg-white" src="{{ opportunity.image ?? asset('img/entity-image.png') }}" alt="{{ 'opportunity'|trans }} | {{ 'image'|trans }}">
-
-                <h2 class="name__entity-details fw-bold ms-2 mt-2 ms-sm-4 mt-sm-3">{{ opportunity.name }}</h2>
-
-                <div class="ms-auto mt-3 d-none d-xxl-inline">
-                    {% include "opportunity/_partials/details/_info-btns.html.twig" %}
-                </div>
-            </div>
-
-            <div class="mb-3 d-xxl-none">
-                {% include "opportunity/_partials/details/_info-btns.html.twig" %}
-            </div>
-
-            <p data-cy="short-description"></p>
-
-            <p class="text-secondary id__entity-details mb-xxl-0">{{ 'view.opportunity.id' | trans }}: {{ opportunity.id }}</p>
-
-            <ul class="nav nav-pills">
-                <li class="nav-item">
-                    <a class="nav-link active" data-bs-toggle="pill" href="#generalData">{{ 'general_data'|trans }}</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" data-bs-toggle="pill" href="#workPlan">{{ 'work_plan'|trans }}</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" data-bs-toggle="pill" href="#events">{{ 'events'|trans }}</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" data-bs-toggle="pill" href="#people">{{ 'people'|trans }}</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" data-bs-toggle="pill" href="#connections">{{ 'connections'|trans }}</a>
-                </li>
-            </ul>
-        </div>
-    </div>
-
-    <div class="container py-4">
-        <div class="tab-content">
-            {% include "opportunity/_partials/details/general-data.html.twig" %}
-
-            {% include "opportunity/_partials/details/work-plan.html.twig" %}
-
-            {% include "opportunity/_partials/details/events.html.twig" %}
-
-            {% include "opportunity/_partials/details/peoples.html.twig" %}
-
-            {% include "opportunity/_partials/details/connections.html.twig" %}
-        </div>
-    </div>
+    <section class="profile-entity-wrapper">
+        {% include "opportunity/_partials/details/content-tabs.html.twig" %}
+    </section>
 {% endblock %}


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Branch?       | improvement/opportunity-details-page                                    |
| Bug fix?      | yes                                                                                                                   |
| New feature?  | no                                                       |
| Deprecations? | no                                |
| Issues        | Fix #522  |

### Resumo das Alterações

neste pr tomei a decisão de desacoplar o componente `entity-header`, que originalmente nasceu acoplado à entidade de agentes.  agora  há uma inversão de controle onde o componente não sabe mais qual entidade ele está exibindo, garantindo que o componente agora seja totalmente agnóstico

### Detalhes 

- **Isolamento de CSS:** removi as classes que estavam no arquivo de estilo de agentes e criei um arquivo CSS específico para o componente.
- **Responsividade e Padronização:** com o componente agora mais escalável, a tela não só está mais responsiva como também segue um padrão 
-  **Tabs:** decidi separar as *tabs* de oportunidades em arquivos próprios
- **Padronização de nomenclatura:** renomeei o arquivo `templates/agent/onde.html.twig` para `templates/agent/details.html.twig`  e irei usar esse padrão nas outras entidads

### Próximos Passos

- Irei utilizar a estrutura deste PR como base para padronizar os *headers* das outras entidades 

### UI
## ANtes
<img width="469" height="834" alt="antes" src="https://github.com/user-attachments/assets/4e347f27-5770-4d83-813a-448ccd348d00" />

<img width="1920" height="817" alt="Screenshot_20260526_204759" src="https://github.com/user-attachments/assets/6c5c4123-2328-4e17-b787-680d8ba49faa" />

## Depois
<img width="440" height="833" alt="Screenshot_20260526_204958" src="https://github.com/user-attachments/assets/7f1cac6a-2208-47e9-b6a9-7b10f3d00ee3" />

<img width="1898" height="828" alt="Screenshot_20260526_205206" src="https://github.com/user-attachments/assets/5911054b-f5dc-4a43-9b29-81e3a29b20a3" />

 